### PR TITLE
Working version for Julia v1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: julia
-sudo: false
+sudo: required
 os:
   - linux
 #  - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ notifications:
 # uncomment the following lines to override the default test script
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'using Pkg, InteractiveUtils; appinfo(); Pkg.clone(pwd()); Pkg.build("GraphIO"); Pkg.test("GraphIO"; coverage=true)'
+  - julia -e 'using Pkg, InteractiveUtils; versioninfo(); Pkg.clone(pwd()); Pkg.build("GraphIO"); Pkg.test("GraphIO"; coverage=true)'
 
 after_success:
     - julia -e 'using Pkg; cd(Pkg.dir("GraphIO")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ os:
 #  - osx
 
 julia:
- - 0.6
+ - 0.7
+ - 1.0
  - nightly
 
 matrix:
@@ -18,10 +19,9 @@ notifications:
 # uncomment the following lines to override the default test script
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'Pkg.add("LightGraphs")'
-  - julia -e 'Pkg.clone(pwd()); Pkg.build("GraphIO"); Pkg.test("GraphIO"; coverage=true)'
+  - julia -e 'using Pkg, InteractiveUtils; appinfo(); Pkg.clone(pwd()); Pkg.build("GraphIO"); Pkg.test("GraphIO"; coverage=true)'
 
 after_success:
-    - julia -e 'cd(Pkg.dir("GraphIO")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
-    - julia -e 'Pkg.add("Documenter")'
-    - julia -e 'cd(Pkg.dir("GraphIO")); include(joinpath("docs", "make.jl"))'
+    - julia -e 'using Pkg; cd(Pkg.dir("GraphIO")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
+    - julia -e 'using Pkg; Pkg.add("Documenter")'
+    - julia -e 'using Pkg; cd(Pkg.dir("GraphIO")); include(joinpath("docs", "make.jl"))'

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 GraphIO provides support to [LightGraphs.jl](https://github.com/JuliaGraphs/LightGraphs.jl) for reading/writing graphs in various formats.
 
+The current version of GraphIO works with Julia version >= 0.7.
+
 Currently, the following functionality is provided:
 
 Format        | Read | Write | Multiple Graphs| Format Name  |

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.6
 LightGraphs 0.9.5
-EzXML 0.4
+EzXML 0.5
 ParserCombinator
 JLD
 SimpleTraits

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
-julia 0.6
+julia 0.7
 LightGraphs 0.9.5
 EzXML 0.5
 ParserCombinator
-JLD
+#JLD
 SimpleTraits

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.7
 LightGraphs 0.9.5
-EzXML 0.5
-ParserCombinator
+EzXML 0.9.0
+ParserCombinator 2.0.0
 #JLD
 SimpleTraits

--- a/src/GraphIO.jl
+++ b/src/GraphIO.jl
@@ -1,4 +1,3 @@
-__precompile__(true)
 module GraphIO
 
 using LightGraphs

--- a/src/GraphIO.jl
+++ b/src/GraphIO.jl
@@ -6,13 +6,14 @@ using SimpleTraits
 
 import LightGraphs: loadgraph, loadgraphs, savegraph, AbstractGraphFormat
 using EzXML
-using ParserCombinator: Parsers.DOT, Parsers.GML
+using ParserCombinator.Parsers.DOT
+using ParserCombinator.Parsers.GML
 
 export DOTFormat, GEXFFormat, GMLFormat, Graph6Format,
 GraphMLFormat, NETFormat, EdgeListFormat, CDFFormat
 # package code goes here
 
-include("jld.jl")
+#include("jld.jl")
 include("dot.jl")
 include("gexf.jl")
 include("gml.jl")

--- a/src/cdf.jl
+++ b/src/cdf.jl
@@ -13,19 +13,19 @@ function _loadcdf(io::IO)
     while !eof(io)
         line = strip(chomp(readline(io)))
         if inbusdata
-            if contains(line, "-999")
+            if occursin("-999", line)
                 inbusdata = false
             else
                 v = parse(Int, split(line)[1])
                 push!(vertices, v)
             end
         elseif inbranchdata
-            if contains(line, "-999")
+            if occursin("-999", line)
                 inbranchdata = false
             else
                 (src_s, dst_s) = split(line)[1:2]
-                src = findfirst(vertices, parse(Int, src_s))
-                dst = findfirst(vertices, parse(Int, dst_s))
+                src = something(findfirst(isequal(parse(Int, src_s)), vertices), 0)
+                dst = something(findfirst(isequal(parse(Int, dst_s)), vertices), 0)
                 push!(srcs, src)
                 push!(dsts, dst)
             end

--- a/src/dot.jl
+++ b/src/dot.jl
@@ -20,7 +20,7 @@ function _dot_read_one_graph(pg::DOT.Graph)
 end
 
 function loaddot(io::IO, gname::String)
-    p = DOT.parse_dot(readstring(io))
+    p = DOT.parse_dot(read(io, String))
     for pg in p
         isdir = pg.directed
         possname = isdir ? DOT.StringID("digraph") : DOT.StringID("graph")
@@ -31,7 +31,7 @@ function loaddot(io::IO, gname::String)
 end
 
 function loaddot_mult(io::IO)
-    p = DOT.parse_dot(readstring(io))
+    p = DOT.parse_dot(read(io, String))
 
     graphs = Dict{String,LightGraphs.AbstractGraph}()
 

--- a/src/edgelist.jl
+++ b/src/edgelist.jl
@@ -2,6 +2,8 @@
 # by commas or whitespace. Will only read the first two elements on
 # each line. Will return a directed graph.
 
+using DelimitedFiles: writedlm
+
 struct EdgeListFormat <: AbstractGraphFormat end
 
 function loadedgelist(io::IO, gname::String)
@@ -33,7 +35,7 @@ function loadedgelist(io::IO, gname::String)
 end
 
 function saveedgelist(io::IO, g::LightGraphs.AbstractGraph, gname::String)
-    writecsv(io, [src(e), dst(e)] for e in collect(LightGraphs.edges(g)))
+    writedlm(io, ([src(e), dst(e)] for e in LightGraphs.edges(g)), ',')
     return 1
 end
 

--- a/src/gml.jl
+++ b/src/gml.jl
@@ -17,8 +17,9 @@ function _gml_read_one_graph(gs, dir)
     end
     return g
 end
+
 function loadgml(io::IO, gname::String)
-    p = GML.parse_dict(readstring(io))
+    p = GML.parse_dict(read(io, String))
     for gs in p[:graph]
         dir = Bool(get(gs, :directed, 0))
         graphname = get(gs, :label, dir ? "digraph" : "graph")
@@ -29,7 +30,7 @@ function loadgml(io::IO, gname::String)
 end
 
 function loadgml_mult(io::IO)
-    p = GML.parse_dict(readstring(io))
+    p = GML.parse_dict(read(io, String))
     graphs = Dict{String,LightGraphs.AbstractGraph}()
     for gs in p[:graph]
         dir = Bool(get(gs, :directed, 0))

--- a/src/graph6.jl
+++ b/src/graph6.jl
@@ -1,7 +1,7 @@
 struct Graph6Format <: AbstractGraphFormat end
 
 function _bv2int(x::BitVector)
-  assert(length(x) <= 8 * sizeof(Int))
+  @assert(length(x) <= 8 * sizeof(Int))
   acc = 0
   for i = 1:length(x)
     acc = acc << 1 + x[i]
@@ -10,7 +10,7 @@ function _bv2int(x::BitVector)
 end
 
 function _int2bv(n::Int, k::Int)
-  bitstr = lstrip(bits(n), '0')
+  bitstr = lstrip(bitstring(n), '0')
   l = length(bitstr)
   padding = k - l
   bv = falses(k)
@@ -25,7 +25,7 @@ function _g6_R(_x::BitVector)::Vector{UInt8}
   padding = cld(k, 6) * 6 - k
   x = vcat(_x, falses(padding))
   nbytes = div(length(x), 6)
-  bytevec = Vector{UInt8}(nbytes)   # uninitialized data!
+  bytevec = Vector{UInt8}(undef, nbytes)   # uninitialized data!
   for i = 1:nbytes
     xslice  = x[((i - 1) * 6 + 1):(i * 6)]
 
@@ -71,7 +71,7 @@ end
 
 
 """
-    \_graphToG6String(g)
+    _graphToG6String(g)
 
 Given a graph `g`, create the corresponding Graph6 string.
 """
@@ -79,7 +79,7 @@ function _graphToG6String(g::LightGraphs.Graph)
   A = adjacency_matrix(g, Bool)
   n = nv(g)
   nbits = div(n * (n - 1), 2)
-  x  = BitVector(nbits)
+  x  = BitVector(undef, nbits)
 
   ind = 0
   for col = 2:n, row = 1:(col - 1)

--- a/src/graphml.jl
+++ b/src/graphml.jl
@@ -17,7 +17,7 @@ function _graphml_read_one_graph(reader::EzXML.StreamReader, isdirected::Bool)
                 tar = reader["target"]
                 push!(xedges, LightGraphs.Edge(nodes[src], nodes[tar]))
             else
-                warn("Skipping unknown node '$(elname)' - further warnings will be suppressed", once=true, key="unknode")
+                @warn "Skipping unknown node '$(elname)' - further warnings will be suppressed" maxlog=1 _id=:unknode
             end
         end
     end
@@ -51,7 +51,7 @@ function loadgraphml(io::IO, gname::String)
             elseif elname == "node" || elname == "edge"
                 # ok
             else
-                warn("Skipping unknown XML element '$(elname)' - further warnings will be suppressed", once=true, key="unkel")
+                @warn "Skipping unknown XML element '$(elname)' - further warnings will be suppressed" maxlog=1 _id=:unkel
             end
         end
     end
@@ -78,7 +78,7 @@ function loadgraphml_mult(io::IO)
                 end
                 graphs[graphname] = _graphml_read_one_graph(reader, directed)
             else
-                warn("Skipping unknown XML element '$(elname)' - further warnings will be suppressed", once=true, key="unkelmult")
+                @warn "Skipping unknown XML element '$(elname)' - further warnings will be suppressed" maxlog=1 _id=:unkelmult
             end
         end
     end

--- a/src/graphml.jl
+++ b/src/graphml.jl
@@ -8,7 +8,7 @@ function _graphml_read_one_graph(reader::EzXML.StreamReader, isdirected::Bool)
     nodeid = 1
     for typ in reader
         if typ == EzXML.READER_ELEMENT
-            elname = EzXML.name(reader)
+            elname = EzXML.nodename(reader)
             if elname == "node"
                 nodes[reader["id"]] = nodeid
                 nodeid += 1
@@ -32,7 +32,7 @@ function loadgraphml(io::IO, gname::String)
     reader = EzXML.StreamReader(io)
     for typ in reader
         if typ == EzXML.READER_ELEMENT
-            elname = EzXML.name(reader)
+            elname = EzXML.nodename(reader)
             if elname == "graphml"
                 # ok
             elseif elname == "graph"
@@ -63,7 +63,7 @@ function loadgraphml_mult(io::IO)
     graphs = Dict{String,LightGraphs.AbstractGraph}()
     for typ in reader
         if typ == EzXML.READER_ELEMENT
-            elname = EzXML.name(reader)
+            elname = EzXML.nodename(reader)
             if elname == "graphml"
                 # ok
             elseif elname == "graph"

--- a/src/net.jl
+++ b/src/net.jl
@@ -32,30 +32,30 @@ function loadnet(io::IO, gname::String = "graph")
     while startswith(line, "%")
         line = readline(io)
     end
-    n = parse(Int, matchall(r"\d+", line)[1])
+    n = parse(Int, match(r"\d+", line).match)
     for ioline in eachline(io)
         line = ioline
-        (ismatch(r"^\*Arcs", line) || ismatch(r"^\*Edges", line)) && break
+        (occursin(r"^\*Arcs", line) || occursin(r"^\*Edges", line)) && break
     end
-    if ismatch(r"^\*Arcs", line)
+    if occursin(r"^\*Arcs", line)
         g = LightGraphs.DiGraph(n)
     else
         g = LightGraphs.Graph(n)
     end
-    while ismatch(r"^\*Arcs", line)
+    while occursin(r"^\*Arcs", line)
         for ioline in eachline(io)
             line = ioline
-            m = matchall(r"\d+", line)
-            length(m) < 2 && break
-            add_edge!(g, parse(Int, m[1]), parse(Int, m[2]))
+            ms = collect(m.match for m in eachmatch(r"\d+", line, overlap=false))
+            length(ms) < 2 && break
+            add_edge!(g, parse(Int, ms[1]), parse(Int, ms[2]))
         end
     end
-    while ismatch(r"^\*Edges", line) # add edges in both directions
+    while occursin(r"^\*Edges", line) # add edges in both directions
         for ioline in eachline(io)
             line = ioline
-            m = matchall(r"\d+", line)
-            length(m) < 2 && break
-            i1, i2 = parse(Int, m[1]), parse(Int, m[2])
+            ms = collect(m.match for m in eachmatch(r"\d+", line, overlap=false))
+            length(ms) < 2 && break
+            i1, i2 = parse(Int, ms[1]), parse(Int, ms[2])
             add_edge!(g, i1, i2)
             add_edge!(g, i2, i1)
         end

--- a/test/graphio.jl
+++ b/test/graphio.jl
@@ -82,8 +82,8 @@ end
     end
     fname = joinpath(testdir, "testdata", "warngraph.graphml")
     
-    @test_warn "Skipping unknown node 'warnnode' - further warnings will be suppressed" loadgraphs(fname, GraphMLFormat())
-    @test_warn "Skipping unknown XML element 'warnelement' - further warnings will be suppressed" loadgraph(fname, "graph", GraphMLFormat())
+    @test_logs (:warn, "Skipping unknown node 'warnnode' - further warnings will be suppressed") match_mode=:any loadgraphs(fname, GraphMLFormat())
+    @test_logs (:warn, "Skipping unknown XML element 'warnelement' - further warnings will be suppressed") match_mode=:any loadgraph(fname, "graph", GraphMLFormat())
     d = loadgraphs(fname, GraphMLFormat())
     write_test(GraphMLFormat(), d)
 end
@@ -145,6 +145,7 @@ end
     @test length(loadgraphs(fname, NETFormat())) == 1
 end
 
+#=
 @testset "JLD" begin
     using JLD
 
@@ -182,6 +183,7 @@ end
         rm(path)
     end
 end
+=#
 
 @testset "CDF" begin
 #test CDFFormat()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using GraphIO
 using LightGraphs
-using Base.Test
+using Test
 
 testdir = dirname(@__FILE__)
 


### PR DESCRIPTION
Now that EzXML has tagged a new version, I would like to tag a version for Julia v1.0.
I've decided to remove (comment out) everything related to JLD as it is unlikely that this will ever work with newer versions of Julia. Eventually we can add support for JLD2.
If nobody objects to these changes, I will merge them soon.