### PR TITLE
Added functionality to save graphs in DOT format

### DIFF
--- a/src/DOT/Dot.jl
+++ b/src/DOT/Dot.jl
@@ -12,30 +12,26 @@ struct DOTFormat <: AbstractGraphFormat end
 
 function savedot(io::IO, g::LightGraphs.AbstractGraph, gname::String = "")
     isdir = LightGraphs.is_directed(g)
-    head = (isdir ? "digraph " : "graph ") * gname * " {"
-    nodes = ""
+    println(io,(isdir ? "digraph " : "graph ") * gname * " {")
     for i in LightGraphs.vertices(g)
-        nodes = nodes * "\n\t" * string(i) * " [label = " * string(i) * "]"
+         println(io,"\t" * string(i))
     end
-    edg = ""
     if isdir
         for u in LightGraphs.vertices(g)
-            n = LightGraphs.outneighbors(g, u)
-            if length(n) == 0
+            out_nbrs = LightGraphs.outneighbors(g, u)
+            if length(out_nbrs) == 0
                 continue
             end
-            s = string(n)
-            edg = edg * "\n\t" * string(u) * " -> {" * s[2:length(s)-1] * "}"
+            println(io, "\t" * string(u) * " -> {" * join(out_nbrs,',') * "}")
         end
     else
         for e in LightGraphs.edges(g)
             source = string(LightGraphs.src(e))
             dest = string(LightGraphs.dst(e))
-            edg = edg * "\n\t" * source * " -- " * dest
+            println(io, "\t" * source * " -- " * dest)
         end
     end
-    dot_string = head * nodes * edg * "\n}\n"
-    print(io, dot_string)
+    println(io,"}")
     return 1
 end
 

--- a/src/DOT/Dot.jl
+++ b/src/DOT/Dot.jl
@@ -4,17 +4,57 @@ using GraphIO.ParserCombinator.Parsers
 using LightGraphs
 using LightGraphs: AbstractGraphFormat
 
-import LightGraphs: loadgraph, loadgraphs
+import LightGraphs: loadgraph, loadgraphs, savegraph
 
 export DOTFormat
 
 struct DOTFormat <: AbstractGraphFormat end
-# TODO: implement save
+
+function savedot(io::IO, g::LightGraphs.AbstractGraph, gname::String = "")
+    isdir = LightGraphs.is_directed(g)
+    head = (isdir ? "digraph " : "graph ") * gname * " {"
+    nodes = ""
+    for i in LightGraphs.vertices(g)
+        nodes = nodes * "\n\t" * string(i) * " [label = " * string(i) * "]"
+    end
+    edg = ""
+    if isdir
+        for u in LightGraphs.vertices(g)
+            n = LightGraphs.outneighbors(g, u)
+            if length(n) == 0
+                continue
+            end
+            s = string(n)
+            edg = edg * "\n\t" * string(u) * " -> {" * s[2:length(s)-1] * "}"
+        end
+    else
+        for e in LightGraphs.edges(g)
+            source = string(LightGraphs.src(e))
+            dest = string(LightGraphs.dst(e))
+            edg = edg * "\n\t" * source * " -- " * dest
+        end
+    end
+    dot_string = head * nodes * edg * "\n}\n"
+    print(io, dot_string)
+    return 1
+end
+
+function savedot_mult(io::IO, graphs::Dict)
+    ng = 0
+    for (gname, g) in graphs
+        ng += savedot(io, g, gname)
+    end
+    return ng
+end
 
 function _dot_read_one_graph(pg::Parsers.DOT.Graph)
     isdir = pg.directed
     nvg = length(Parsers.DOT.nodes(pg))
-    nodedict = Dict(zip(collect(Parsers.DOT.nodes(pg)), 1:nvg))
+    nodedict = try
+            Dict(i => parse(Int64,string(i)) for i in Parsers.DOT.nodes(pg))
+        catch
+            Dict(zip(collect(Parsers.DOT.nodes(pg)), 1:nvg))
+    end
     if isdir
         g = LightGraphs.DiGraph(nvg)
     else
@@ -55,5 +95,7 @@ end
 
 loadgraph(io::IO, gname::String, ::DOTFormat) = loaddot(io, gname)
 loadgraphs(io::IO, ::DOTFormat) = loaddot_mult(io)
+savegraph(io::IO, g::AbstractGraph, gname::String, ::DOTFormat) = savedot(io, g, gname)
+savegraph(io::IO, d::Dict, ::DOTFormat) = savedot_mult(io, d)
 
 end #module

--- a/src/DOT/Dot.jl
+++ b/src/DOT/Dot.jl
@@ -46,11 +46,7 @@ end
 function _dot_read_one_graph(pg::Parsers.DOT.Graph)
     isdir = pg.directed
     nvg = length(Parsers.DOT.nodes(pg))
-    nodedict = try
-            Dict(i => parse(Int64,string(i)) for i in Parsers.DOT.nodes(pg))
-        catch
-            Dict(zip(collect(Parsers.DOT.nodes(pg)), 1:nvg))
-    end
+    nodedict = Dict(zip(collect(Parsers.DOT.nodes(pg)), 1:nvg))
     if isdir
         g = LightGraphs.DiGraph(nvg)
     else

--- a/src/DOT/Dot.jl
+++ b/src/DOT/Dot.jl
@@ -19,7 +19,7 @@ function savedot(io::IO, g::LightGraphs.AbstractGraph, gname::String = "")
     if isdir
         for u in LightGraphs.vertices(g)
             out_nbrs = LightGraphs.outneighbors(g, u)
-        length(out_nbrs) == 0 && continue
+            length(out_nbrs) == 0 && continue
             println(io, "\t" * string(u) * " -> {" * join(out_nbrs,',') * "}")
         end
     else

--- a/src/DOT/Dot.jl
+++ b/src/DOT/Dot.jl
@@ -19,9 +19,7 @@ function savedot(io::IO, g::LightGraphs.AbstractGraph, gname::String = "")
     if isdir
         for u in LightGraphs.vertices(g)
             out_nbrs = LightGraphs.outneighbors(g, u)
-            if length(out_nbrs) == 0
-                continue
-            end
+        length(out_nbrs) == 0 && continue
             println(io, "\t" * string(u) * " -> {" * join(out_nbrs,',') * "}")
         end
     else

--- a/test/DOT/runtests.jl
+++ b/test/DOT/runtests.jl
@@ -14,22 +14,30 @@ using LightGraphs.Experimental
     read_test(DOTFormat(), dg, "g2", fname)
     read_test_mult(DOTFormat(), Dict{String,AbstractGraph}("g1"=>g, "g2"=>dg), fname)
 	
-	fname = joinpath(testdir, "testdata", "savedgraphs.dot")
-	
+	#tests for multiple graphs
+
+	fname = joinpath(testdir, "testdata", "saved3graphs.dot")
 	#connected graph
 	g1 = SimpleGraph(5,10)	
 	#disconnected graph
 	g2 = SimpleGraph(5,2)
 	#directed graph
 	dg = SimpleDiGraph(5,8)
-
 	GraphDict = Dict("g1" => g1, "g2" => g2, "dg" => dg)
 	write_test(DOTFormat(), GraphDict, fname, remove = false, silent = true)
-	
+
 	#adding this test because currently the Parser returns unordered vertices
 	@test has_isomorph(loadgraph(fname, "g1", DOTFormat()), g1)
 	@test has_isomorph(loadgraph(fname, "g2", DOTFormat()), g2)
 	@test has_isomorph(loadgraph(fname, "dg", DOTFormat()), dg)
 
 	rm(fname)
+
+	#tests for single graph
+
+	fname = joinpath(testdir, "testdata", "saved1graph.dot")
+	write_test(DOTFormat(), g1, "g1", fname, remove = false, silent = true)
+	@test has_isomorph(loadgraph(fname, "g1", DOTFormat()), g1)
+
+	rm(fname)	
 end

--- a/test/DOT/runtests.jl
+++ b/test/DOT/runtests.jl
@@ -1,6 +1,7 @@
 using Test
 using ParserCombinator
 using GraphIO.DOT
+using LightGraphs.Experimental
 
 @testset "DOT" begin
     g = CompleteGraph(6)
@@ -12,4 +13,23 @@ using GraphIO.DOT
     read_test(DOTFormat(), g, "g1", fname, testfail=true)
     read_test(DOTFormat(), dg, "g2", fname)
     read_test_mult(DOTFormat(), Dict{String,AbstractGraph}("g1"=>g, "g2"=>dg), fname)
+	
+	fname = joinpath(testdir, "testdata", "savedgraphs.dot")
+	
+	#connected graph
+	g1 = SimpleGraph(5,10)	
+	#disconnected graph
+	g2 = SimpleGraph(5,2)
+	#directed graph
+	dg = SimpleDiGraph(5,8)
+
+	GraphDict = Dict("g1" => g1, "g2" => g2, "dg" => dg)
+	write_test(DOTFormat(), GraphDict, fname, remove = false, silent = true)
+	
+	#adding this test because currently the Parser returns unordered vertices
+	@test has_isomorph(loadgraph(fname, "g1", DOTFormat()), g1)
+	@test has_isomorph(loadgraph(fname, "g2", DOTFormat()), g2)
+	@test has_isomorph(loadgraph(fname, "dg", DOTFormat()), dg)
+
+	rm(fname)
 end

--- a/test/DOT/runtests.jl
+++ b/test/DOT/runtests.jl
@@ -35,9 +35,13 @@ using LightGraphs.Experimental
 
 	#tests for single graph
 
-	fname = joinpath(testdir, "testdata", "saved1graph.dot")
-	write_test(DOTFormat(), g1, "g1", fname, remove = false, silent = true)
-	@test has_isomorph(loadgraph(fname, "g1", DOTFormat()), g1)
+	fname1 = joinpath(testdir, "testdata", "saved1graph.dot")
+	write_test(DOTFormat(), g1, "g1", fname1, remove = false, silent = true)
+	@test has_isomorph(loadgraph(fname1, "g1", DOTFormat()), g1)
+	fname2 = joinpath(testdir, "testdata", "saved1digraph.dot")
+	write_test(DOTFormat(), dg, "dg", fname2, remove = false, silent = true)
+	@test has_isomorph(loadgraph(fname2, "dg", DOTFormat()), dg)	
 
-	rm(fname)	
+	rm(fname1)
+	rm(fname2)	
 end


### PR DESCRIPTION
 #19 
```julia
julia> using ParserCombinator,LightGraphs,GraphIO

julia> x = SimpleGraph(5,10)
{5, 10} undirected simple Int64 graph

julia> y = SimpleDiGraph(5,10)
{5, 10} directed simple Int64 graph

julia> savegraph("/home/abhinav/undirected.dot",x,"undg",DOTFormat())
┌ Warning: `GraphIO.DOTFormat`  has been moved to submodule `GraphIO.DOT` and needs `ParserCombinator.jl` to be imported first. I.e. use
│     using ParserCombinator
│     GraphIO.DOT.DOTFormat()
│   caller = top-level scope at none:0
└ @ Core none:0
1

julia> savegraph("/home/abhinav/directed.dot",y,"dg",DOTFormat())
┌ Warning: `GraphIO.DOTFormat`  has been moved to submodule `GraphIO.DOT` and needs `ParserCombinator.jl` to be imported first. I.e. use
│     using ParserCombinator
│     GraphIO.DOT.DOTFormat()
│   caller = top-level scope at none:0
└ @ Core none:0
1

julia> p = loadgraph("/home/abhinav/undirected.dot","undg",DOTFormat())
┌ Warning: `GraphIO.DOTFormat`  has been moved to submodule `GraphIO.DOT` and needs `ParserCombinator.jl` to be imported first. I.e. use
│     using ParserCombinator
│     GraphIO.DOT.DOTFormat()
│   caller = top-level scope at none:0
└ @ Core none:0
{5, 10} undirected simple Int64 graph

julia> q = loadgraph("/home/abhinav/directed.dot","dg",DOTFormat())
┌ Warning: `GraphIO.DOTFormat`  has been moved to submodule `GraphIO.DOT` and needs `ParserCombinator.jl` to be imported first. I.e. use
│     using ParserCombinator
│     GraphIO.DOT.DOTFormat()
│   caller = top-level scope at none:0
└ @ Core none:0
{5, 10} directed simple Int64 graph

julia> p == x
true

julia> q == y
true

```