### PR TITLE
Add IntEdgeListFormat

### DIFF
--- a/src/Edgelist/Edgelist.jl
+++ b/src/Edgelist/Edgelist.jl
@@ -52,4 +52,6 @@ loadgraph(io::IO, gname::String, ::EdgeListFormat) = loadedgelist(io, gname)
 loadgraphs(io::IO, ::EdgeListFormat) = Dict("graph" => loadedgelist(io, "graph"))
 savegraph(io::IO, g::AbstractGraph, gname::String, ::EdgeListFormat) = saveedgelist(io, g, gname)
 
+include("IntEdgeList.jl")
+
 end

--- a/src/Edgelist/IntEdgeList.jl
+++ b/src/Edgelist/IntEdgeList.jl
@@ -1,0 +1,48 @@
+export IntEdgeListFormat
+
+struct IntEdgeListFormat <: AbstractGraphFormat
+    offset::Int64
+end
+IntEdgeListFormat(;offset = 0) = IntEdgeListFormat(offset)
+
+function loadintedgelist(io::IO, gname::String, offset::Int64)
+    elist = Vector{Tuple{Int64, Int64}}()
+    nvg = 0
+    neg = 0
+    fadjlist = Vector{Vector{Int64}}()
+    for x in eachline(io)
+        i = 1
+        while x[i] != ' ' && x[i] != ','
+            i += 1
+        end
+        s = parse(Int64, x[1:i-1])
+        while x[i] == ' ' || x[i] == ','
+            i += 1
+        end
+        ii = i
+        while i <= length(x) && x[i] != ' '
+            i += 1
+        end
+        d = parse(Int64, x[ii:i-1])
+        s = s-offset
+        d = d-offset
+        if nvg < max(s, d)
+            nvg = max(s, d)
+            append!(fadjlist, [Vector{Int64}() for _ in 1:nvg-length(fadjlist)])
+        end
+        push!(fadjlist[s], d)
+        neg += 1
+    end
+    sort!.(fadjlist)
+    badjlist = [Vector{Int64}() for _ in 1:nvg]
+    for u = 1:nvg
+    	for v in fadjlist[u]
+    		push!(badjlist[v], u)
+    	end
+    end
+    return LightGraphs.DiGraph(neg, fadjlist, badjlist)
+end
+
+loadgraph(io::IO, gname::String, fmt::IntEdgeListFormat) = loadintedgelist(io, gname, fmt.offset)
+loadgraphs(io::IO, fmt::IntEdgeListFormat) = Dict("graph" => loadintedgelist(io, "graph", fmt.offset))
+savegraph(io::IO, g::AbstractGraph, gname::String, ::IntEdgeListFormat) = saveedgelist(io, g, gname)

--- a/test/Edgelist/runtests.jl
+++ b/test/Edgelist/runtests.jl
@@ -1,9 +1,11 @@
 using Test
 using GraphIO.EdgeList
+using GraphIO.EdgeList: IntEdgeListFormat
 
 @testset "EdgeList" begin
     for g in values(digraphs)
         readback_test(EdgeListFormat(), g)
+        readback_test(IntEdgeListFormat(), g)
     end
 end
 


### PR DESCRIPTION
Optimized the old PR to get more speedup.

**Benchmarks -**

```julia
julia> using LightGraphs, SNAPDatasets, GraphIO

julia> fn = pwd()*"/elist"
"/home/abhinav/GraphIO.jl/elist"

julia> g = loadsnap(:amazon0302)
{262111, 1234877} directed simple UInt32 graph

julia> savegraph(fn, g, EdgeListFormat())
1

julia> using GraphIO.EdgeList: EdgeListFormat, IntEdgeListFormat

julia> @elapsed loadgraph(fn, IntEdgeListFormat())
0.662574325

julia> @elapsed loadgraph(fn, EdgeListFormat())
3.050738991

julia> g = loadsnap(:web_google)
{875711, 5105027} directed simple UInt32 graph

julia> fn = pwd()*"/elist2"
"/home/abhinav/GraphIO.jl/elist2"

julia> savegraph(fn, g, EdgeListFormat())
1

julia> @elapsed loadgraph(fn, EdgeListFormat())
14.229083196

julia> @elapsed loadgraph(fn, IntEdgeListFormat())
3.576119252
```