### PR TITLE
README: use true URL links for format name

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ GraphIO provides support to [Graphs.jl](https://github.com/JuliaGraphs/Graphs.jl
 
 Currently, the following functionality is provided:
 
-Format        | Read | Write | Multiple Graphs| Format Name  |
---------------|------|-------|----------------|--------------|
-[EdgeList]    |   ✓  |  ✓    |                |EdgeListFormat|
+Format        | Read | Write | Multiple Graphs| Format Name  | Comment  |
+--------------|------|-------|----------------|--------------|----------|
+EdgeList      |   ✓  |  ✓    |                |EdgeListFormat| a simple list of sources and dests separated by whitespace and/or comma, one pair per line. |
 [GML]         |   ✓  |  ✓    | ✓              |GMLFormat     |
 [Graph6]      |   ✓  |  ✓    | ✓              |Graph6Format  |
 [GraphML]     |   ✓  |  ✓    | ✓              |GraphMLFormat |
@@ -18,13 +18,6 @@ Format        | Read | Write | Multiple Graphs| Format Name  |
 [DOT]         |   ✓  |       | ✓              |DOTFormat     |
 [CDF]         |   ✓  |       |                |CDFFormat     |
 
-[EdgeList]: a simple list of sources and dests separated by whitespace and/or comma, one pair per line.
-[GML]: https://en.wikipedia.org/wiki/Graph_Modelling_Language
-[Graph6]: https://users.cecs.anu.edu.au/~bdm/data/formats.html
-[GraphML]: https://en.wikipedia.org/wiki/GraphML
-[Pajek NET]: https://gephi.org/users/supported-graph-formats/pajek-net-format/
-[GEXF]: https://gephi.org/gexf/format/
-[DOT]: https://en.wikipedia.org/wiki/DOT_(graph_description_language)
 
 Graphs are read using either the `loadgraph` function or, for formats that support multiple graphs in a single file,
 the `loadgraphs` functions. `loadgraph` returns a Graph object, while `loadgraphs` returns a dictionary of Graph objects.
@@ -35,4 +28,10 @@ For example, an edgelist file could be loaded as:
 graph = loadgraph("path_to_graph/my_edgelist.txt", "graph_key", EdgeListFormat())
 ``` 
 
-
+[CDF]: http://www2.ee.washington.edu/research/pstca/formats/cdf.txt
+[GML]: https://en.wikipedia.org/wiki/Graph_Modelling_Language
+[Graph6]: https://users.cecs.anu.edu.au/~bdm/data/formats.html
+[GraphML]: https://en.wikipedia.org/wiki/GraphML
+[Pajek NET]: https://gephi.org/users/supported-graph-formats/pajek-net-format/
+[GEXF]: https://gephi.org/gexf/format/
+[DOT]: https://en.wikipedia.org/wiki/DOT_(graph_description_language)


### PR DESCRIPTION
A minor visual improvement I believe.