### PR TITLE
Update compat, tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,20 +15,20 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
-          - '1.9'
-          - 'nightly'
+          - '1.10'
+          - '1'
+          - 'pre'
         os:
           - ubuntu-latest
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         env:
           cache-name: cache-artifacts
         with:
@@ -41,6 +41,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v4
         with:
           file: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.7.0"
 [deps]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
-Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SimpleTraits = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
 
 [weakdeps]
@@ -21,14 +20,16 @@ GraphIOGraphMLExt = "EzXML"
 GraphIOLGCompressedExt = "CodecZlib"
 
 [compat]
+Aqua = "0.8.9"
 CodecZlib = "0.7"
 DelimitedFiles = "1"
 EzXML = "1"
 Graphs = "1.4"
+JuliaFormatter = "1.0.62"
 ParserCombinator = "2.1"
-Requires = "1"
 SimpleTraits = "0.9"
-julia = "1"
+Test = "1"
+julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GraphIO
 
 [![Build Status](https://github.com/JuliaGraphs/GraphIO.jl/workflows/CI/badge.svg)](https://github.com/JuliaGraphs/GraphIO.jl/actions?query=workflow%3ACI+branch%3Amaster)
-[![codecov.io](http://codecov.io/github/JuliaGraphs/GraphIO.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaGraphs/GraphIO.jl?branch=master)
+[![codecov](https://codecov.io/github/JuliaGraphs/GraphIO.jl/graph/badge.svg?token=8Vw9q0ofeT)](https://codecov.io/github/JuliaGraphs/GraphIO.jl)
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 [![Aqua QA](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 

--- a/src/GraphIO.jl
+++ b/src/GraphIO.jl
@@ -1,25 +1,5 @@
 module GraphIO
 
-@static if !isdefined(Base, :get_extension)
-    using Requires
-end
-
-@static if !isdefined(Base, :get_extension)
-    function __init__()
-        @require CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193" begin
-            include("../ext/GraphIOLGCompressedExt.jl")
-        end
-        @require EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615" begin
-            include("../ext/GraphIOGEXFExt.jl")
-            include("../ext/GraphIOGraphMLExt.jl")
-        end
-        @require ParserCombinator = "fae87a5f-d1ad-5cf0-8f61-c941e1580b46" begin
-            include("../ext/GraphIODOTExt.jl")
-            include("../ext/GraphIOGMLExt.jl")
-        end
-    end
-end
-
 include("CDF/Cdf.jl")
 include("DOT/Dot.jl")
 include("Edgelist/Edgelist.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,11 +15,7 @@ include("graphio.jl")
 # write your own tests here
 @testset verbose = true "GraphIO" begin
     @testset "Code quality" begin
-        Aqua.test_all(GraphIO; stale_deps=false, project_toml_formatting=false)
-        Aqua.test_stale_deps(GraphIO; ignore=[:Requires])
-        if VERSION >= v"1.9"
-            Aqua.test_project_toml_formatting(GraphIO)
-        end
+        Aqua.test_all(GraphIO)
     end
     @testset "Code formatting" begin
         @test JuliaFormatter.format(GraphIO; verbose=false, overwrite=false)


### PR DESCRIPTION
- Bump Julia lower bound to 1.10 (new LTS)
- Remove Requires dependency for extensions
- Update CI script with latest versions of all actions
- Update Codecov badge
- Update Aqua tests