### PR TITLE
Fix dead links from gephi.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,5 +54,5 @@ The current design avoids populating your environment with unnecessary dependenc
 [Graph6]: https://users.cecs.anu.edu.au/~bdm/data/formats.html
 [GraphML]: https://en.wikipedia.org/wiki/GraphML
 [Pajek NET]: https://docs.gephi.org/desktop/User_Manual/Import/Pajek_NET_Format
-[GEXF]: https://gephi.org/gexf/format/
+[GEXF]: https://docs.gephi.org/desktop/User_Manual/Import/GEXF_File_Format
 [DOT]: https://en.wikipedia.org/wiki/DOT_(graph_description_language)

--- a/README.md
+++ b/README.md
@@ -53,6 +53,6 @@ The current design avoids populating your environment with unnecessary dependenc
 [GML]: https://en.wikipedia.org/wiki/Graph_Modelling_Language
 [Graph6]: https://users.cecs.anu.edu.au/~bdm/data/formats.html
 [GraphML]: https://en.wikipedia.org/wiki/GraphML
-[Pajek NET]: https://gephi.org/users/supported-graph-formats/pajek-net-format/
+[Pajek NET]: https://docs.gephi.org/desktop/User_Manual/Import/Pajek_NET_Format
 [GEXF]: https://gephi.org/gexf/format/
 [DOT]: https://en.wikipedia.org/wiki/DOT_(graph_description_language)

--- a/src/NET/Net.jl
+++ b/src/NET/Net.jl
@@ -12,7 +12,7 @@ struct NETFormat <: AbstractGraphFormat end
 """
     savenet(io, g, gname="g")
 
-Write a graph `g` to an IO stream `io` in the [Pajek NET](http://gephi.github.io/users/supported-graph-formats/pajek-net-format/)
+Write a graph `g` to an IO stream `io` in the [Pajek NET](https://docs.gephi.org/desktop/User_Manual/Import/Pajek_NET_Format)
 format. Return 1 (number of graphs written).
 """
 function savenet(io::IO, g::Graphs.AbstractGraph, gname::String="g")
@@ -32,7 +32,7 @@ end
 """
     loadnet(io::IO, gname="graph")
 
-Read a graph from IO stream `io` in the [Pajek NET](http://gephi.github.io/users/supported-graph-formats/pajek-net-format/)
+Read a graph from IO stream `io` in the [Pajek NET](https://docs.gephi.org/desktop/User_Manual/Import/Pajek_NET_Format)
 format. Return the graph.
 """
 function loadnet(io::IO, gname::String="graph")


### PR DESCRIPTION
That project retired their old wiki late 2025, but the links here were not updated. 

I debated if this should link to the actual specifications instead of a third party site, but in both cases I found gephi's site much more intuitive to read. As far as I can tell the library does not implement the full spec anyway, so the more accessible version is still the better choice in my opinion.